### PR TITLE
Bumped MAX_PRECISION to 9

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -40,7 +40,7 @@ use crate::num_rational::Rational64;
 /// Because we base our implementation on rational numbers which can map
 /// to an infinite sequence in the decimal system we have to put an
 /// upper limit on the maximum precision we can display.
-const MAX_PRECISION: usize = 8;
+const MAX_PRECISION: usize = 9;
 
 
 /// Round the given `BigRational` to the nearest integer. Rounding

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -196,10 +196,10 @@ mod tests {
 
   #[test]
   fn serialize_json() {
-    let num = Num::from_str("14827.9102").unwrap();
+    let num = Num::from_str("14827.910289765").unwrap();
     let json = to_json(&num).unwrap();
 
-    assert_eq!(json, r#""14827.9102""#);
+    assert_eq!(json, r#""14827.910289765""#);
   }
 
   /// Check that we can serialize to `bincode` and back.

--- a/tests/test_num.rs
+++ b/tests/test_num.rs
@@ -348,13 +348,13 @@ fn num_format_precision_round() {
 #[test]
 fn num_max_precision() {
   let num = Num::new(1, 3);
-  assert_eq!(num.to_string(), "0.33333333")
+  assert_eq!(num.to_string(), "0.333333333")
 }
 
 #[test]
 fn num_max_precision_with_rounding() {
   let num = Num::new(2, 3);
-  assert_eq!(num.to_string(), "0.66666667")
+  assert_eq!(num.to_string(), "0.666666667")
 }
 
 #[test]
@@ -391,14 +391,14 @@ fn num_minimum_precision() {
   );
   assert_eq!(
     format!("{}", Num::new(1, 3).display().min_precision(2)),
-    "0.33333333"
+    "0.333333333"
   );
   assert_eq!(
     format!("{}", Num::new(2, 3).display().min_precision(2)),
-    "0.66666667"
+    "0.666666667"
   );
-  assert_eq!(format!("{}", Num::new(1, 3).display()), "0.33333333");
-  assert_eq!(format!("{}", Num::new(2, 3).display()), "0.66666667");
+  assert_eq!(format!("{}", Num::new(1, 3).display()), "0.333333333");
+  assert_eq!(format!("{}", Num::new(2, 3).display()), "0.666666667");
   assert_eq!(format!("{:.2}", Num::new(1, 3).display()), "0.33");
   assert_eq!(format!("{:.2}", Num::new(2, 3).display()), "0.67");
 }


### PR DESCRIPTION
The `num_decimal` crate is used as the number type for [apca](https://docs.rs/apca/latest/apca/) - the Alpaca Brokerage client library.

Alpaca's decimal precision is 9 ([see here](https://docs.rs/apca/latest/apca/)), and the MAX_PRECISION of 8 was leading to rounding errors when executing orders with Alpaca.